### PR TITLE
Add a `__hash__` method to Record.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Add `__hash__` method to Record.
 
 3.3 (2017-05-06)
 ----------------

--- a/src/Record/__init__.py
+++ b/src/Record/__init__.py
@@ -116,6 +116,9 @@ class Record(Base):
     def __len__(self):
         return len(self.__schema__)
 
+    def __hash__(self):
+        return hash(self.__data__) + hash(tuple(self.__schema__.items()))
+
     def __lt__(self, other):
         if isinstance(other, Record):
             return self.__data__ < other.__data__

--- a/src/Record/__init__.py
+++ b/src/Record/__init__.py
@@ -117,7 +117,7 @@ class Record(Base):
         return len(self.__schema__)
 
     def __hash__(self):
-        return hash(self.__data__) + hash(tuple(self.__schema__.items()))
+        return id(self)
 
     def __lt__(self, other):
         if isinstance(other, Record):

--- a/src/Record/tests.py
+++ b/src/Record/tests.py
@@ -173,13 +173,13 @@ class RecordTest(unittest.TestCase):
     def test_hash(self):
         r1 = R((1, 2, None))
         r2 = R((1, 2, None))
-        self.assertEqual(hash(r1), hash(r2))
+        self.assertNotEqual(hash(r1), hash(r2))
 
     def test_hash_schema(self):
         r = R((1, 2, None))
         r_same = RSameSchema((1, 2, None))
         r_diff = RDifferentSchema((1, 2, None))
-        self.assertEqual(hash(r), hash(r_same))
+        self.assertNotEqual(hash(r), hash(r_same))
         self.assertNotEqual(hash(r), hash(r_diff))
 
     def test_set_members(self):
@@ -191,15 +191,10 @@ class RecordTest(unittest.TestCase):
         records.add(r2)
         self.assertTrue(r1 in records)
         self.assertTrue(r2 in records)
-        # r3 is in the set, as it represent the same data as r1/r2,
-        # compares equal to it and hashes to the same value
-        self.assertTrue(r3 in records)
-        # Since all the values are equal, the set has a length of one
-        self.assertEqual(len(records), 1)
-        # A record with the same data, but a different schema, has
-        # a different hash.
-        records.add(r_diff)
+        self.assertFalse(r3 in records)
         self.assertEqual(len(records), 2)
+        records.add(r_diff)
+        self.assertEqual(len(records), 3)
         self.assertTrue(r_diff in records)
 
     def test_cmp(self):

--- a/src/Record/tests.py
+++ b/src/Record/tests.py
@@ -29,6 +29,14 @@ class R(Record):
     __record_schema__ = {'a': 0, 'b': 1, 'c': 2}
 
 
+class RSameSchema(Record):
+    __record_schema__ = {'a': 0, 'b': 1, 'c': 2}
+
+
+class RDifferentSchema(Record):
+    __record_schema__ = {'x': 0, 'y': 1, 'z': 2}
+
+
 class RecordTest(unittest.TestCase):
 
     def test_init(self):
@@ -161,6 +169,38 @@ class RecordTest(unittest.TestCase):
     def test_len(self):
         r = R((1, 2, None))
         self.assertEqual(len(r), 3)
+
+    def test_hash(self):
+        r1 = R((1, 2, None))
+        r2 = R((1, 2, None))
+        self.assertEqual(hash(r1), hash(r2))
+
+    def test_hash_schema(self):
+        r = R((1, 2, None))
+        r_same = RSameSchema((1, 2, None))
+        r_diff = RDifferentSchema((1, 2, None))
+        self.assertEqual(hash(r), hash(r_same))
+        self.assertNotEqual(hash(r), hash(r_diff))
+
+    def test_set_members(self):
+        r1 = R((1, 2, None))
+        r2 = R((1, 2, None))
+        r3 = R((1, 2, None))
+        r_diff = RDifferentSchema((1, 2, None))
+        records = set([r1])
+        records.add(r2)
+        self.assertTrue(r1 in records)
+        self.assertTrue(r2 in records)
+        # r3 is in the set, as it represent the same data as r1/r2,
+        # compares equal to it and hashes to the same value
+        self.assertTrue(r3 in records)
+        # Since all the values are equal, the set has a length of one
+        self.assertEqual(len(records), 1)
+        # A record with the same data, but a different schema, has
+        # a different hash.
+        records.add(r_diff)
+        self.assertEqual(len(records), 2)
+        self.assertTrue(r_diff in records)
 
     def test_cmp(self):
         r1 = R((1, 2, 0))


### PR DESCRIPTION
This is in response to zopefoundation/Products.ZSQLMethods#3.

I've added a hash method to Record, which takes into account both the data and schema of the instance.

I tried to write tests to explain what that means, especially when having Record instances with the same schema and same data: they are all equal and only get added once to a set, even if they come from two different classes with the same schema.

I'm not convinced this is actually the right behavior. I could be convinced that ``id(self)`` might be the better semantic for record instances.